### PR TITLE
NullReferenceException on a valid use case

### DIFF
--- a/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
+++ b/System.Collections.Immutable/src/System/Collections/Immutable/ImmutableList`1.cs
@@ -1281,7 +1281,7 @@ namespace System.Collections.Immutable
         /// <exception cref="System.NotImplementedException"></exception>
         bool IList.Contains(object value)
         {
-            return this.Contains((T)value);
+            return (value is T || (value == null && default(T) == null)) && this.Contains((T)value);
         }
 
         /// <summary>
@@ -1294,7 +1294,10 @@ namespace System.Collections.Immutable
         /// <exception cref="System.NotImplementedException"></exception>
         int IList.IndexOf(object value)
         {
-            return this.IndexOf((T)value);
+            if (value is T || (value == null && default(T) == null))
+                return this.IndexOf((T)value);
+            else
+                return -1;
         }
 
         /// <summary>


### PR DESCRIPTION
```csharp
var list = ImmutableList.Create(1,2,3);
list.Contains(null); // throws, should return false (check with any other collection out there)
```

The bug exists in Microsoft's collections, but alredy fixed in their codebase, subject of the next release one assumes.

Same might need to be fixed in other collections: ImmutableArray etc.